### PR TITLE
Set wgExternalLinkTarget to _blank

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -234,3 +234,8 @@ $wgUploadDirectory = "/var/mediawiki-images";
  */
 $wgCacheDirectory = "/var/mediawiki-cache";
 
+/**
+ * When running in the Sandstorm iframe, external links will not be followed
+ * unless they are target="_blank"
+ */
+$wgExternalLinkTarget = "_blank";


### PR DESCRIPTION
When running in the Sandstorm iframe, external links will not be followed unless they are target="_blank"

You can see this behavior by creating a new wikimedia grain in Sandstorm, then clicking any of the links to MediaWiki.org on the default Main Page.

My browser - Chrome - just doesn't do anything unless I control-click or right-click -> open in new tab.

Sorry, I haven't tested this change - but I'm %90 this is what's needed. :)
