### PR TITLE
Update LocalSettings.php to change external link target

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -235,3 +235,8 @@ $wgScriptExtension  = ".php";
 $wgCacheDirectory = "/var/mediawiki-cache";
 
 $wgMaxUploadSize = 100 * 1024 * 1024;
+
+/**
+ * Open external links in new tab *
+ */
+ $wgExternalLinkTarget = '_blank';


### PR DESCRIPTION
Intended to address #10 (would require testing within Sandstorm environment)

Adds MediaWiki setting to cause external links to open in new tab. Reference: https://www.mediawiki.org/wiki/Manual:$wgExternalLinkTarget
