### PR TITLE
Load the 'cite' package so that <ref> tags work

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -240,3 +240,6 @@ $wgMaxUploadSize = 100 * 1024 * 1024;
  * Open external links in new tab *
  */
  $wgExternalLinkTarget = '_blank';
+
+// Load the cite package so the <ref> and <references/> tags work
+wfLoadExtension( 'Cite' );


### PR DESCRIPTION
According to the [MediaWiki documentation](https://www.mediawiki.org/wiki/Extension:Cite), the 'cite' extension is bundled with the version of MediaWiki currently available on Sandstorm---but it isn't enabled by default.  The cite extension provides the `<ref>` and `<references/>` tags widely used on MediaWiki-based sites and which is a key feature for how I'd like to use the wiki.

If I've read the [documentation](https://www.mediawiki.org/wiki/Extension:Cite#Installation) correctly, adding this line should enable the extension, but please note that I haven't tested this.

Whether you accept this PR or not, thank you for packaging MediaWiki for Sandstorm.